### PR TITLE
Fix mocha init.

### DIFF
--- a/lib/setup-browser.js
+++ b/lib/setup-browser.js
@@ -13,7 +13,7 @@ require('mocha/mocha');
 
 var _mocha = new Mocha();
 _mocha.reporter('{{REPORTER}}');
-_mocha.suite.emit('pre-require', window);
+_mocha.suite.emit('pre-require', window, '', _mocha);
 
 setTimeout(function () {
   Mocha.process.stdout = process.stdout;

--- a/lib/setup-node.js
+++ b/lib/setup-node.js
@@ -10,7 +10,7 @@
 var Mocha = require('mocha');
 var _mocha = new Mocha();
 _mocha.reporter('{{REPORTER}}');
-_mocha.suite.emit('pre-require', global);
+_mocha.suite.emit('pre-require', global, '', _mocha);
 
 setTimeout(function () {
   _mocha.run(function (errs) {


### PR DESCRIPTION
Pass mocha instance when emitting `pre-require` event, that makes `it.only` and `describe.only` work.
