### PR TITLE
Add support for third party reporters

### DIFF
--- a/lib/mocaccino.js
+++ b/lib/mocaccino.js
@@ -13,6 +13,7 @@ var through = require('through2');
 var resolve = require('resolve');
 var listen  = require('listen');
 var supportsColor = require('supports-color');
+var mochaReporters = require('mocha').reporters;
 
 
 module.exports = function (b, opts) {
@@ -39,6 +40,15 @@ module.exports = function (b, opts) {
         return { main : pkg.browser };
       }
     });
+    if (!mochaReporters[reporter]) {
+      var reporterFile = resolve.sync(reporter, {
+        baseDir: __dirname
+      });
+      b.add(reporterFile);
+      b.require(reporterFile, {
+        expose: reporter
+      });
+    }
     var broutPath = path.relative(process.cwd(), broutFile);
     b.require('./' + broutPath.replace(/\\/g, '/'), {
       expose : 'brout'

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "mocha": "^2.2",
+    "mocha-jenkins-reporter": "^0.1.9",
     "jslint": "^0.8",
     "phantomic": "^1.0",
     "browserify": "^10.2",

--- a/test/mocaccino-test.js
+++ b/test/mocaccino-test.js
@@ -242,6 +242,22 @@ describe('plugin', function () {
       });
     });
 
+    it('uses custom reporter', function (done) {
+      var b = browserify();
+      b.add('./test/fixture/test-pass');
+      b.plugin(mocaccino, { reporter : 'mocha-jenkins-reporter' });
+      run('phantomic', [], b, function (err, code, out) {
+        /*jslint regexp: true*/
+        if (err) {
+          done(err);
+        } else {
+          assert.equal(code, 0);
+          assert(/passes\:.*[0-9]+ms/.test(out), out);
+          done();
+        }
+      });
+    });
+
     it('uses ui "bdd"', function (done) {
       var b = browserify();
       b.add('./test/fixture/test-pass');
@@ -380,6 +396,25 @@ describe('plugin', function () {
       var b = browserify(bundleOptionsBare);
       b.add('./test/fixture/test-pass');
       b.plugin(mocaccino, { node : true, reporter : 'list' });
+      run('node', [], b, function (err, code, out) {
+        /*jslint regexp: true*/
+        if (err) {
+          done(err);
+        } else {
+          assert.equal(code, 0);
+          assert(/passes\:.*[0-9]+ms/.test(out), out);
+          done();
+        }
+      });
+    });
+
+    it('uses custom reporter', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-pass');
+      b.plugin(mocaccino, {
+        node : true,
+        reporter : 'mocha-jenkins-reporter'
+      });
       run('node', [], b, function (err, code, out) {
         /*jslint regexp: true*/
         if (err) {


### PR DESCRIPTION
This is related to issue #11.

I managed to make it work by requiring and adding the custom reporter before the transformations made by mocaccino, this way the reporter maps to the correct mocha version as intended.

Thoughts on implementation:
   - Needed to require mocha on mocaccino.js to get the reporters object so it could check if report is built in or not.
   - If the reporter is not built in it tries to require it, adds it to the bundle with `b.add()` and then exposes it in a way mocha can find it.
   - Custom reporters already work on node so the changes only apply to the browser runtime.

**Notice:** I'm quite new to mocaccino and even browserify itself, so let me know if there is a better way to code this.

Also wrote some tests for it based on the current ones.

Please take a look and ping me if need to do anything else or differently entirely :smile:.