### PR TITLE
Solves the reporter aliases problem, as Mocha support it from 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/mantoni/mocaccino.js.git"
   },
   "dependencies": {
-    "mocha": "^2.2",
+    "mocha": "^2.3",
     "through2": "^1.1",
     "resolve": "^1.0",
     "brout": "^1.0",


### PR DESCRIPTION
As discussed on issue #13 some people might have problems with built-in reporters if using versions of Mocha older than `2.3.0`. 

In older versions of `mocha` reporter aliases did not exist. So, for example, people trying to use `spec` as the reporter would receive an error because `mocaccino@1.6.0` would interpret that as a custom reporter when it's not. In those cases you would have to use `Spec` instead to get the correct behavior.

In Mocha > `2.3.0` this is no longer a problem.

The reason it's currently working for most of us is that the current version stated in `mocaccino's package.json` dependencies is `^2.2` so it would map to any version up to the most recent version of Mocha before `3.0`.

That would be OK unless you already have a Mocha version between `2.2` and `3.0` on **your** `package.json`, then NPM would interpret that your mocha version fits the requirements and it would use your version instead of installing mocaccino's one. Thus preventing a duplicate dependency.

I think the best option is to make `mocaccino` depend on Mocha `^2.3`.