### PR TITLE
Add regex support to --grep option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ where OPTIONS are:
 
   --reporter, -R  Mocha reporter to use, defaults to "tap"
   --grep          Mocha grep option
+  --fgrep         Mocha fgrep option
   --invert        Mocha invert option
   --timeout, -t   Mocha timeout in milliseconds to use, defaults to 2000
   --ui, -U        Mocha user interface to use, defaults to "bdd"

--- a/lib/mocaccino.js
+++ b/lib/mocaccino.js
@@ -21,7 +21,8 @@ module.exports = function (b, opts) {
     opts = {};
   }
   var reporter = opts.reporter || opts.R || 'tap';
-  var grep = opts.grep || '';
+  var grep = opts.grep instanceof RegExp ? opts.grep.source
+    : (opts.grep || '');
   var invert = opts.invert;
   var yields = opts.yields || opts.y || 250;
   var ui = opts.ui || opts.U || 'bdd';

--- a/lib/mocaccino.js
+++ b/lib/mocaccino.js
@@ -23,6 +23,7 @@ module.exports = function (b, opts) {
   var reporter = opts.reporter || opts.R || 'tap';
   var grep = opts.grep instanceof RegExp ? opts.grep.source
     : (opts.grep || '');
+  var fgrep = opts.fgrep || '';
   var invert = opts.invert;
   var yields = opts.yields || opts.y || 250;
   var ui = opts.ui || opts.U || 'bdd';
@@ -74,6 +75,7 @@ module.exports = function (b, opts) {
       .replace('\'{{TIMEOUT}}\'', timeout)
       .replace('\'{{USE_COLORS}}\'', colors ? 'true' : 'false')
       .replace('{{GREP}}', grep)
+      .replace('{{FGREP}}', fgrep)
       .replace('\'{{INVERT}}\'', invert ? 'true' : 'false');
     onSetupFile(null, setupContent);
   });

--- a/lib/setup-browser.js
+++ b/lib/setup-browser.js
@@ -12,8 +12,9 @@ require('brout');
 
 Mocha.reporters.Base.window.width = JSON.parse('{{WINDOW_WIDTH}}');
 Mocha.reporters.Base.symbols.dot = '.';
-var mocha = new Mocha();
-mocha.grep('{{GREP}}');
+var mocha = new Mocha({
+  grep: '{{GREP}}'
+});
 if ('{{INVERT}}' === true) {
   mocha.invert();
 }

--- a/lib/setup-browser.js
+++ b/lib/setup-browser.js
@@ -12,8 +12,11 @@ require('brout');
 
 Mocha.reporters.Base.window.width = JSON.parse('{{WINDOW_WIDTH}}');
 Mocha.reporters.Base.symbols.dot = '.';
+var grep = '{{GREP}}';
+var fgrep = '{{FGREP}}';
 var mocha = new Mocha({
-  grep: '{{GREP}}'
+  grep: grep.length ? grep : undefined,
+  fgrep: fgrep.length ? fgrep : undefined
 });
 if ('{{INVERT}}' === true) {
   mocha.invert();

--- a/lib/setup-node.js
+++ b/lib/setup-node.js
@@ -10,8 +10,11 @@
 var Mocha = require('mocha');
 Mocha.reporters.Base.window.width = JSON.parse('{{WINDOW_WIDTH}}');
 Mocha.reporters.Base.symbols.dot = '.';
+var grep = '{{GREP}}';
+var fgrep = '{{FGREP}}';
 var _mocha = new Mocha({
-  grep: '{{GREP}}'
+  grep: grep.length ? grep : undefined,
+  fgrep: fgrep.length ? fgrep : undefined
 });
 _mocha.ui('{{UI}}');
 if ('{{INVERT}}' === true) {

--- a/lib/setup-node.js
+++ b/lib/setup-node.js
@@ -10,9 +10,10 @@
 var Mocha = require('mocha');
 Mocha.reporters.Base.window.width = JSON.parse('{{WINDOW_WIDTH}}');
 Mocha.reporters.Base.symbols.dot = '.';
-var _mocha = new Mocha();
+var _mocha = new Mocha({
+  grep: '{{GREP}}'
+});
 _mocha.ui('{{UI}}');
-_mocha.grep('{{GREP}}');
 if ('{{INVERT}}' === true) {
   _mocha.invert();
 }

--- a/test/fixture/test-fgrep.js
+++ b/test/fixture/test-fgrep.js
@@ -1,0 +1,21 @@
+/*
+ * mocaccino.js
+ *
+ * Copyright (c) 2014 Maximilian Antoni <mail@maxantoni.de>
+ *
+ * @license MIT
+ */
+/*globals describe, it*/
+'use strict';
+
+describe('fixture', function () {
+
+  it('passes (.*)', function () {
+    return;
+  });
+
+  it('passes without regex', function () {
+    return;
+  });
+
+});

--- a/test/fixture/test-grep.js
+++ b/test/fixture/test-grep.js
@@ -18,4 +18,8 @@ describe('fixture', function () {
     return;
   });
 
+  it('passes with regex grep', function () {
+    return;
+  });
+
 });

--- a/test/mocaccino-test.js
+++ b/test/mocaccino-test.js
@@ -117,7 +117,27 @@ function unFlaggedGrepAssert(done) {
   return function (err, code, out) {
     var expected = '1..%num\n'
       + 'ok 1 fixture passes flag\n'
-      + 'ok %num fixture passes without flag\n'
+      + 'ok 2 fixture passes without flag\n'
+      + 'ok %num fixture passes with regex grep\n'
+      + '# tests %num\n'
+      + '# pass %num\n'
+      + '# fail 0\n';
+
+    if (err) {
+      done(err);
+    } else {
+      assert.equal(out, expected.replace(NUM_TESTS_RE, '3'));
+      assert.equal(code, 0);
+      done();
+    }
+  };
+}
+
+function regexGrepAssert(done) {
+  return function (err, code, out) {
+    var expected = '1..%num\n'
+      + 'ok 1 fixture passes without flag\n'
+      + 'ok %num fixture passes with regex grep\n'
       + '# tests %num\n'
       + '# pass %num\n'
       + '# fail 0\n';
@@ -135,7 +155,8 @@ function unFlaggedGrepAssert(done) {
 function invertedFlaggedGrepAssert(done) {
   return function (err, code, out) {
     var expected = '1..%num\n'
-      + 'ok %num fixture passes without flag\n'
+      + 'ok 1 fixture passes without flag\n'
+      + 'ok %num fixture passes with regex grep\n'
       + '# tests %num\n'
       + '# pass %num\n'
       + '# fail 0\n';
@@ -143,7 +164,7 @@ function invertedFlaggedGrepAssert(done) {
     if (err) {
       done(err);
     } else {
-      assert.equal(out, expected.replace(NUM_TESTS_RE, '1'));
+      assert.equal(out, expected.replace(NUM_TESTS_RE, '2'));
       assert.equal(code, 0);
       done();
     }
@@ -195,6 +216,20 @@ describe('plugin', function () {
       b.add('./test/fixture/test-grep');
       b.plugin(mocaccino);
       run('phantomic', [], b, unFlaggedGrepAssert(done));
+    });
+
+    it('treats string grep as a regular expression', function (done) {
+      var b = browserify();
+      b.add('./test/fixture/test-grep');
+      b.plugin(mocaccino, {'grep': 'with(out)?'});
+      run('phantomic', [], b, regexGrepAssert(done));
+    });
+
+    it('treats RegExp grep as a regular expression', function (done) {
+      var b = browserify();
+      b.add('./test/fixture/test-grep');
+      b.plugin(mocaccino, {'grep': /with(out)?/});
+      run('phantomic', [], b, regexGrepAssert(done));
     });
 
     it('inverts filter when invert is set', function (done) {
@@ -361,6 +396,20 @@ describe('plugin', function () {
       b.add('./test/fixture/test-grep');
       b.plugin(mocaccino, {'node': true});
       run('node', [], b, unFlaggedGrepAssert(done));
+    });
+
+    it('treats string grep as a regular expression', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-grep');
+      b.plugin(mocaccino, {'grep': 'with(out)?', 'node': true});
+      run('node', [], b, regexGrepAssert(done));
+    });
+
+    it('treats RegExp grep as a regular expression', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-grep');
+      b.plugin(mocaccino, {'grep': /with(out)?/, 'node': true});
+      run('node', [], b, regexGrepAssert(done));
     });
 
     it('inverts filter when invert is set', function (done) {

--- a/test/mocaccino-test.js
+++ b/test/mocaccino-test.js
@@ -152,6 +152,24 @@ function regexGrepAssert(done) {
   };
 }
 
+function regexFgrepAssert(done) {
+  return function (err, code, out) {
+    var expected = '1..%num\n'
+      + 'ok 1 fixture passes (.*)\n'
+      + '# tests %num\n'
+      + '# pass %num\n'
+      + '# fail 0\n';
+
+    if (err) {
+      done(err);
+    } else {
+      assert.equal(out, expected.replace(NUM_TESTS_RE, '1'));
+      assert.equal(code, 0);
+      done();
+    }
+  };
+}
+
 function invertedFlaggedGrepAssert(done) {
   return function (err, code, out) {
     var expected = '1..%num\n'
@@ -230,6 +248,13 @@ describe('plugin', function () {
       b.add('./test/fixture/test-grep');
       b.plugin(mocaccino, {'grep': /with(out)?/});
       run('phantomic', [], b, regexGrepAssert(done));
+    });
+
+    it('treats fgrep as an ordinary string', function (done) {
+      var b = browserify();
+      b.add('./test/fixture/test-fgrep');
+      b.plugin(mocaccino, {'fgrep': 'passes (.*)'});
+      run('phantomic', [], b, regexFgrepAssert(done));
     });
 
     it('inverts filter when invert is set', function (done) {
@@ -410,6 +435,13 @@ describe('plugin', function () {
       b.add('./test/fixture/test-grep');
       b.plugin(mocaccino, {'grep': /with(out)?/, 'node': true});
       run('node', [], b, regexGrepAssert(done));
+    });
+
+    it('treats fgrep as an ordinary string', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-fgrep');
+      b.plugin(mocaccino, {'fgrep': 'passes (.*)', 'node': true});
+      run('node', [], b, regexFgrepAssert(done));
     });
 
     it('inverts filter when invert is set', function (done) {


### PR DESCRIPTION
Changes the behavior of the `--grep` option to treat its value as a regular expression, to more accurately match the behavior of Mocha.  Also adds an `--fgrep` option that corresponds to Mocha's `--fgrep` option, which matches the old behavior of `--grep` (treating the argument as a string, not a regular expression).  This should simplify the version update for any existing users who depend on the old behavior of `--grep`.

_Fixes issue #15_