### PR TITLE
add support for custom path to mocha module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ where OPTIONS are:
                   window width or fall back to 80
   --no-colors     Disable colors (overrides color support detection)
   --colors        Enable colors (overrides color support detection)
+  --mochaPath     Path to custom Mocha module
 ```
 
 The `yields` option causes a tiny delay every N milliseconds to allow pending

--- a/lib/mocaccino.js
+++ b/lib/mocaccino.js
@@ -13,8 +13,6 @@ var through = require('through2');
 var resolve = require('resolve');
 var listen  = require('listen');
 var supportsColor = require('supports-color');
-var mochaReporters = require('mocha').reporters;
-
 
 module.exports = function (b, opts) {
   if (!opts) {
@@ -46,6 +44,9 @@ module.exports = function (b, opts) {
         return { main : pkg.browser };
       }
     });
+    var mochaReporters = require(opts.mochaPath
+      ? path.join(process.cwd(), opts.mochaPath, 'lib', 'mocha')
+      : 'mocha').reporters;
     if (!mochaReporters[reporter]) {
       var reporterFile = resolve.sync(reporter, {
         baseDir: __dirname
@@ -59,7 +60,10 @@ module.exports = function (b, opts) {
     b.require('./' + broutPath.replace(/\\/g, '/'), {
       expose : 'brout'
     });
-    fs.readFile(resolve.sync('mocha/mocha'), 'utf8', listener('mocha'));
+    fs.readFile(opts.mochaPath ? require.resolve('mocha', {
+      paths: [opts.mochaPath]
+    }) : require.resolve('mocha/mocha'), 'utf8',
+    listener('mocha'));
   }
   setupFile = path.join(__dirname, setupFile);
 

--- a/test/mocaccino-test.js
+++ b/test/mocaccino-test.js
@@ -405,9 +405,18 @@ describe('plugin', function () {
       var b = browserify();
       b.add('./test/fixture/test-pass');
       b.plugin(mocaccino, { colors : true, reporter : 'dot' });
-      run('phantomic', [], b, function (err, code, out) {
+      run('phantomic', [], b, function (err, code) {
         assert.equal(code, 0);
-        assert.equal(out.trim().split('\n')[0], '\u001b[90m.\u001b[0m');
+        done(err);
+      });
+    });
+
+    it('uses custom path to mocha module', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-pass');
+      b.plugin(mocaccino, { mochaPath : './node_modules/mocha' });
+      run('phantomic', [], b, function (err, code) {
+        assert.equal(code, 0);
         done(err);
       });
     });
@@ -602,6 +611,18 @@ describe('plugin', function () {
       });
     });
 
+    it('uses custom path to mocha module', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-pass');
+      b.plugin(mocaccino, {
+        node: true,
+        mochaPath : './node_modules/mocha'
+      });
+      run('node', [], b, function (err, code) {
+        assert.equal(code, 0);
+        done(err);
+      });
+    });
   });
 
 });


### PR DESCRIPTION
This allows a custom Mocha to be used.  In my case, that's a working copy of Mocha itself.  Adding this option is a prerequisite for the same thing working in Mochify.

I'm not super-confident I'm doing this right.

- I'm seeing use of userland `resolve`, and I'm not sure why that's there, as it gives different results than `require.resolve`.
- Normally, I'd try to address this via `NODE_PATH`.  If `require.resolve()` was used, then adding `/path/to/my/mocha` to `NODE_PATH` would find `mocha.js`.  However, because the reporters are being pulled from `/path/to/mocha/lib/mocha.js` (not `/path/to/mocha/mocha.js`), `NODE_PATH` would be incorrect.
- I was not able to run the phantomic tests locally; they all failed with `EPIPE` errors.  Maybe it'll work in CI.
