### PR TITLE
fix problems with custom mocha path

### DIFF
--- a/lib/mocaccino.js
+++ b/lib/mocaccino.js
@@ -45,7 +45,7 @@ module.exports = function (b, opts) {
       }
     });
     var mochaReporters = require(opts.mochaPath
-      ? path.join(process.cwd(), opts.mochaPath, 'lib', 'mocha')
+      ? path.resolve(process.cwd(), opts.mochaPath, 'lib', 'mocha')
       : 'mocha').reporters;
     if (!mochaReporters[reporter]) {
       var reporterFile = resolve.sync(reporter, {
@@ -60,8 +60,9 @@ module.exports = function (b, opts) {
     b.require('./' + broutPath.replace(/\\/g, '/'), {
       expose : 'brout'
     });
+
     var mochaPath = opts.mochaPath
-      ? resolve.sync('mocha/mocha', { paths: [opts.mochaPath] })
+      ? resolve.sync('mocha.js', { paths: [opts.mochaPath] })
       : resolve.sync('mocha/mocha');
     fs.readFile(mochaPath, 'utf8', listener('mocha'));
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mocaccino",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/mocaccino-test.js
+++ b/test/mocaccino-test.js
@@ -14,7 +14,7 @@ var coverify   = require('coverify');
 var listen     = require('listen');
 var spawn      = require('child_process').spawn;
 var mocaccino  = require('../lib/mocaccino');
-
+var path       = require('path');
 
 function run(proc, args, b, done) {
   var l = listen();
@@ -411,7 +411,7 @@ describe('plugin', function () {
       });
     });
 
-    it('uses custom path to mocha module', function (done) {
+    it('uses custom relative path to mocha module', function (done) {
       var b = browserify();
       b.add('./test/fixture/test-pass');
       b.plugin(mocaccino, { mochaPath : './node_modules/mocha' });
@@ -421,6 +421,17 @@ describe('plugin', function () {
       });
     });
 
+    it('uses custom absolute path to mocha module', function (done) {
+      var b = browserify();
+      b.add('./test/fixture/test-pass');
+      b.plugin(mocaccino, {
+        mochaPath : path.join(process.cwd(), 'node_modules', 'mocha')
+      });
+      run('phantomic', [], b, function (err, code) {
+        assert.equal(code, 0);
+        done(err);
+      });
+    });
   });
 
   describe('node', function () {
@@ -611,12 +622,25 @@ describe('plugin', function () {
       });
     });
 
-    it('uses custom path to mocha module', function (done) {
+    it('uses custom relative path to mocha module', function (done) {
       var b = browserify(bundleOptionsBare);
       b.add('./test/fixture/test-pass');
       b.plugin(mocaccino, {
         node: true,
         mochaPath : './node_modules/mocha'
+      });
+      run('node', [], b, function (err, code) {
+        assert.equal(code, 0);
+        done(err);
+      });
+    });
+
+    it('uses custom absolute path to mocha module', function (done) {
+      var b = browserify(bundleOptionsBare);
+      b.add('./test/fixture/test-pass');
+      b.plugin(mocaccino, {
+        node: true,
+        mochaPath : path.join(process.cwd(), 'node_modules', 'mocha')
       });
       run('node', [], b, function (err, code) {
         assert.equal(code, 0);


### PR DESCRIPTION
This fixes broken absolute paths.  Also it seems that we weren't actually getting the expected file as seen on L65.  This is cumbersome to test; we'd need to copy `node_modules/mocha` to a temp dir then assert the correct path was present in the call to `fs.readFile`, which means we'd want a spy...