### PR TITLE
Fix test

### DIFF
--- a/test/mocaccino-test.js
+++ b/test/mocaccino-test.js
@@ -668,7 +668,7 @@ describe('plugin', function () {
     it('enables colors', function (done) {
       var b = browserify(bundleOptionsBare);
       b.add('./test/fixture/test-pass');
-      b.plugin(mocaccino, { node : true, color : true, reporter : 'dot' });
+      b.plugin(mocaccino, { node : true, colors : true, reporter : 'dot' });
       run('node', [], b, function (err, code, out) {
         assert.equal(code, 0);
         assert.equal(out.trim().split('\n')[0], '\u001b[90m.\u001b[0m');


### PR DESCRIPTION
This fixes a typo in test configuration that fails tests when `colors` defaults to `false`.  Other test cases also use the config `colors` rather than `color`.